### PR TITLE
Remove extra header includes

### DIFF
--- a/SVProgressHUD/include/SVIndefiniteAnimatedView.h
+++ b/SVProgressHUD/include/SVIndefiniteAnimatedView.h
@@ -1,1 +1,0 @@
-../SVIndefiniteAnimatedView.h

--- a/SVProgressHUD/include/SVProgressAnimatedView.h
+++ b/SVProgressHUD/include/SVProgressAnimatedView.h
@@ -1,1 +1,0 @@
-../SVProgressAnimatedView.h

--- a/SVProgressHUD/include/SVRadialGradientLayer.h
+++ b/SVProgressHUD/include/SVRadialGradientLayer.h
@@ -1,1 +1,0 @@
-../SVRadialGradientLayer.h


### PR DESCRIPTION
The following header includes are removed from build phases to resolve "Umbrella header for module 'SVProgressHUD' does not include header" warning.

- 'SVIndefiniteAnimatedView.h'
- 'SVProgressAnimatedView.h'
- 'SVRadialGradientLayer.h'